### PR TITLE
feature/gha-0008 rename environments

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,16 @@ inputs:
     description: "GitHub token for authenticating with the GitHub API"
     required: true
 
+  org-short-name:
+    description: "GitHub organization short name to be used in environment names"
+    required: true
+    default: "sb"
+
+  region:
+    description: "AWS region to be used in environment names"
+    required: true
+    default: "us-east-1"
+
 branding:
   icon: 'package'
   color: 'blue'

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "release": {
-    "extends": "./scripts/plugins/release.config.js"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/subhamay-bhattacharyya-gha/check-environments-action.git"

--- a/src/index.js
+++ b/src/index.js
@@ -10,29 +10,22 @@ async function run() {
     const octokit = github.getOctokit(token);
     const repo = github.context.repo;
 
-    const baseEnvs = ['ci', 'devl', 'test', 'prod'];
+    const requiredEnvs = ['ci', `${orgShortName}-devl-${region}`, `${orgShortName}-test-${region}`, `${orgShortName}-prod-${region}`];
     const envStatus = {};
 
-    const requiredEnvs = baseEnvs.map(env => {
-      if (env === 'ci') {
-        return 'ci'; // No prefix/suffix for CI
-      }
-      return `${orgShortName}-${env}-${region}`;
-    });
-
-    for (const envName of requiredEnvs) {
+  for (const env of requiredEnvs) {
       try {
         await octokit.rest.repos.getEnvironment({
           owner: repo.owner,
           repo: repo.repo,
-          environment_name: envName,
+          environment_name: env,
         });
-        core.info(`Environment '${envName}' exists.`);
-        envStatus[envName] = true;
+        core.info(`Environment '${env}' exists.`);
+        envStatus[env] = true;
       } catch (error) {
         if (error.status === 404) {
-          core.warning(`Environment '${envName}' does not exist. Run the Setup Environments workflow first.`);
-          envStatus[envName] = false;
+          core.warning(`Environment '${env}' does not exist.`);
+          envStatus[env] = false;
         } else {
           throw error;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,32 @@ const fs = require('fs');
 async function run() {
   try {
     const token = core.getInput('github-token');
-    const orgShortName = core.getInput('org-short-name') || '';
-    const region = core.getInput('region') || '';
+    const orgShortName = core.getInput('org-short-name').trim();
+    const region = core.getInput('region').trim();
     const octokit = github.getOctokit(token);
     const repo = github.context.repo;
 
     const requiredEnvs = ['ci', `${orgShortName}-devl-${region}`, `${orgShortName}-test-${region}`, `${orgShortName}-prod-${region}`];
     const envStatus = {};
 
-  for (const env of requiredEnvs) {
+    if (!token) {
+      core.setFailed('Missing required input: github-token');
+      return;
+    }
+
+    if (!orgShortName) {
+      core.setFailed('Missing required input: org-short-name');
+      return;
+    }
+
+    if (!region) {
+      core.setFailed('Missing required input: region');
+      return;
+    }
+
+    core.info(`Checking environments for repository: ${requiredEnvs.join(', ')}`);
+
+    for (const env of requiredEnvs) {
       try {
         await octokit.rest.repos.getEnvironment({
           owner: repo.owner,


### PR DESCRIPTION
This pull request introduces enhancements to the environment-checking logic in the GitHub Action, adds new configurable inputs for organization and region, and removes unused configuration in `package.json`. The most important changes include updating the environment names dynamically based on new inputs, improving error handling for missing inputs, and enhancing the summary output with additional information.

### Enhancements to environment-checking logic:

* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R8-R32): Updated the `requiredEnvs` array to dynamically include environment names based on new `org-short-name` and `region` inputs. Added error handling for missing inputs (`github-token`, `org-short-name`, and `region`) and improved logging with `core.info`.
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R72-R77): Enhanced the summary output to include the organization short name and region if provided.

### New configurable inputs:

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR8-R17): Added `org-short-name` and `region` as new inputs with default values (`sb` and `us-east-1`, respectively). These inputs are used to dynamically generate environment names.

### Code cleanup:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-L32): Removed unused `release` configuration related to `release.config.js` to simplify the package configuration.