### PR TITLE
fix: correct syntax error in package.json by adding missing comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "@semantic-release/release-notes-generator": "^14.0.3",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
-    "@vercel/ncc": "^0.38.3"
-    "semantic-release": "^24.2.6",
+    "@vercel/ncc": "^0.38.3",
+    "semantic-release": "^24.2.6"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This pull request includes a minor formatting adjustment to the `package.json` file. The change ensures consistent comma placement between dependencies.